### PR TITLE
Start using SourceLink in DiaSymReader.Converter

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,6 +16,7 @@
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta1-63011-01</MicrosoftMetadataVisualizerVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <MicrosoftNETFrameworkReferenceAssembliesVersion>1.0.0-alpha-004</MicrosoftNETFrameworkReferenceAssembliesVersion>
+    <MicrosoftSourceLinkVersion>1.0.0-beta2-19270-01</MicrosoftSourceLinkVersion>
 
     <!-- CoreFX -->
     <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,7 +16,6 @@
     <MicrosoftMetadataVisualizerVersion>1.0.0-beta1-63011-01</MicrosoftMetadataVisualizerVersion>
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
     <MicrosoftNETFrameworkReferenceAssembliesVersion>1.0.0-alpha-004</MicrosoftNETFrameworkReferenceAssembliesVersion>
-    <MicrosoftSourceLinkVersion>1.0.0-beta2-19270-01</MicrosoftSourceLinkVersion>
 
     <!-- CoreFX -->
     <SystemCollectionsImmutableVersion>1.5.0</SystemCollectionsImmutableVersion>

--- a/src/Microsoft.DiaSymReader.Converter/Microsoft.DiaSymReader.Converter.csproj
+++ b/src/Microsoft.DiaSymReader.Converter/Microsoft.DiaSymReader.Converter.csproj
@@ -20,8 +20,6 @@
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.SourceLink.Vsts.Git" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.DiaSymReader.Converter.UnitTests" />

--- a/src/Microsoft.DiaSymReader.Converter/Microsoft.DiaSymReader.Converter.csproj
+++ b/src/Microsoft.DiaSymReader.Converter/Microsoft.DiaSymReader.Converter.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Description>Converter between Windows PDB and Portable PDB formats.</Description>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageTags>DiaSymReader ISymUnmanagedReader Portable PDB debugging conversion</PackageTags>
@@ -19,6 +20,8 @@
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
+    <PackageReference Include="Microsoft.SourceLink.Vsts.Git" Version="$(MicrosoftSourceLinkVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.DiaSymReader.Converter.UnitTests" />


### PR DESCRIPTION
Closes: https://github.com/dotnet/arcade/issues/2898

Make DiaSymReader.Converter use SourceLink so we can consume it in Arcade.GenFacades and have Arcade builds pass source link validation.

/cc: @tmat @jcagme