### PR TITLE
Handle global usings with extern aliases

### DIFF
--- a/src/Microsoft.DiaSymReader.Converter/PdbConverterPortableToWindows.cs
+++ b/src/Microsoft.DiaSymReader.Converter/PdbConverterPortableToWindows.cs
@@ -1077,6 +1077,15 @@ namespace Microsoft.DiaSymReader.Tools
                 }
             }
 
+            // no alias defined in scope for given assembly -> must be a 'global' using, use the first defined alias
+            foreach (var (assemblyRefHandle, alias) in aliasedAssemblyRefs)
+            {
+                if (targetAssembly == assemblyRefHandle)
+                {
+                    return alias;
+                }
+            }
+
             return null;
         }
 


### PR DESCRIPTION
Fixes a failure in the Razor build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2649968&view=logs&j=7c8326b9-0a5f-532a-e6de-db8515c72d9a&t=2f0f1e20-badc-52e7-dbc6-29a52429fc6c&l=298 caused by code that looks like this: https://github.com/dotnet/razor/blob/4c649b28a3ea6b0ec0e97a9e24b2f108555c014c/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GlobalUsings.cs

I just grabbed the latest code from PdbWriter.cs in Roslyn, which is where the rest of the method came from:
https://github.com/dotnet/roslyn/blob/main/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs#L446-L453

None of the tests hit that method at all, and I don't know what mojo the `Imports.cmd` does, but it didn't work on my machine to update that dll/pdb. If you have any pointers, I'm all ears!