### PR TITLE
Clean-up: Remove xml headers, copyright notices, use TFM properties, …

### DIFF
--- a/eng/DiaSymReaderNative.targets
+++ b/eng/DiaSymReaderNative.targets
@@ -1,6 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project>
+﻿<Project>
 
   <PropertyGroup>
     <!-- 
@@ -31,6 +29,7 @@
       <Pack>false</Pack>
     </Content>
 
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" ExcludeAssets="all"/>
+    <PackageDownload Include="Microsoft.DiaSymReader.Native" Version="[$(MicrosoftDiaSymReaderNativeVersion)]" />
   </ItemGroup>
+
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project>
-   <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
-   </PropertyGroup>
-</Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project>	
-  <ItemGroup>	
+﻿<Project>
+
+  <ItemGroup>
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
-  </ItemGroup>	
+  </ItemGroup>
+
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project>
+
   <PropertyGroup>
     <VersionPrefix>1.1.0</VersionPrefix>
     <PreReleaseVersionLabel>beta2</PreReleaseVersionLabel>
     <SemanticVersioningV1>true</SemanticVersioningV1>
     <UsingToolNuGetRepack>true</UsingToolNuGetRepack>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
+
     <!-- libs -->
     <MicrosoftCodeAnalysisPooledObjectsVersion>4.1.0-1.21523.2</MicrosoftCodeAnalysisPooledObjectsVersion>
     <MicrosoftCodeAnalysisDebuggingVersion>4.1.0-1.21523.2</MicrosoftCodeAnalysisDebuggingVersion>
@@ -20,4 +20,5 @@
     <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <SystemTextJsonVersion>5.0.0</SystemTextJsonVersion>
   </PropertyGroup>
+
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,12 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project>
+﻿<Project>
+
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
   <PropertyGroup>
-    <LangVersion>Preview</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>annotations</Nullable>
-    <Nullable Condition="'$(TargetFramework)' != 'net472'">enable</Nullable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <!-- The minimum supported versions of this repo. -->
+    <NetMinimum>net8.0</NetMinimum>
+    <NetFrameworkMinimum>net472</NetFrameworkMinimum>
   </PropertyGroup>
+
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,30 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project>
+﻿<Project>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
-  <!-- 
-    Workaround for https://github.com/NuGet/Home/issues/6754: cyclic dependency.
-  -->
   <PropertyGroup>
-    <_ProjectDefinedPackageId>$(PackageId)</_ProjectDefinedPackageId>
-    <PackageId>*fake_packageid_for_project_$(MSBuildProjectName)*</PackageId>
-    <BeforePack>$(BeforePack);_UpdatePackageId</BeforePack>
+    <Nullable Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">enable</Nullable>
   </PropertyGroup>
 
-  <!--
-     Workaround for cyclic package reference. PackageId is set to an invalid value above (in evaluation phase to be picked up by Restore),
-     then updated to the actual value before Pack target.
-
-     Note: $(BeforePack) is used instead of BeforeTargets="$(PackDependsOn)" because PackDependsOn now includes
-     _GetRestoreProjectStyle (NuGet/NuGet.Client#6712), which would cause this target to run during Restore and
-     undo the fake PackageId before the restore graph is built.
-  -->
-  <Target Name="_UpdatePackageId">
-    <PropertyGroup>
-      <PackageId>$(_ProjectDefinedPackageId)</PackageId>
-      <PackageId Condition="'$(PackageId)' == ''">$(AssemblyName)</PackageId>
-      <PackageId Condition="'$(PackageId)' == ''">$(MSBuildProjectName)</PackageId>
-    </PropertyGroup>
-  </Target>
 </Project>

--- a/src/Microsoft.DiaSymReader.Converter.Tests/Microsoft.DiaSymReader.Converter.UnitTests.csproj
+++ b/src/Microsoft.DiaSymReader.Converter.Tests/Microsoft.DiaSymReader.Converter.UnitTests.csproj
@@ -1,16 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
+    <TargetFrameworks>$(BundledNETCoreAppTargetFramework);$(NetFrameworkMinimum)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- 
       We would need to download 32bit dotnet cli, which would add extra time to PR runs 
       Testing 64bit only on Desktop suffixiently covers our interop code paths.  
     -->
-    <TestArchitectures Condition="'$(TargetFramework)' == 'net472'">x64;x86</TestArchitectures>
-
+    <TestArchitectures Condition="'$(TargetFramework)' == '$(NetFrameworkMinimum)'">x64;x86</TestArchitectures>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Metadata.Visualizer" Version="$(MicrosoftMetadataVisualizerVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbVersion)" />
@@ -21,4 +20,5 @@
   </ItemGroup>
 
   <Import Project="$(RepositoryEngineeringDir)DiaSymReaderNative.targets" />
+
 </Project>

--- a/src/Microsoft.DiaSymReader.Converter.Xml/Microsoft.DiaSymReader.Converter.Xml.csproj
+++ b/src/Microsoft.DiaSymReader.Converter.Xml/Microsoft.DiaSymReader.Converter.Xml.csproj
@@ -1,8 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetFrameworkMinimum)</TargetFrameworks>
     <RootNamespace>Microsoft.DiaSymReader.Tools</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -16,6 +15,7 @@
     <!-- Workaround for https://github.com/dotnet/sdk/issues/11270 -->
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Microsoft.DiaSymReader.Converter\Utilities\HResult.cs" Link="Utilities\HResult.cs" />
     <Compile Include="..\Microsoft.DiaSymReader.Converter\Utilities\StreamUtilities.cs" Link="Utilities\StreamUtilities.cs" />
@@ -23,6 +23,7 @@
     <Compile Include="..\Microsoft.DiaSymReader.Converter\Utilities\SymMetadataProvider.cs" Link="Utilities\SymMetadataProvider.cs" />
     <Compile Include="..\Microsoft.DiaSymReader.Converter\Utilities\DummySymReaderMetadataProvider.cs" Link="Utilities\DummySymReaderMetadataProvider.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" />
@@ -32,6 +33,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.PooledObjects" Version="$(MicrosoftCodeAnalysisPooledObjectsVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Debugging" Version="$(MicrosoftCodeAnalysisDebuggingVersion)" PrivateAssets="all" />
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Update="PdbToXmlResources.resx" GenerateSource="true" />
     <EmbeddedResource Update="ConverterResources.resx" GenerateSource="true" />
@@ -45,4 +47,5 @@
       <Link Condition="'%(NuGetPackageId)' != ''">%(NuGetPackageId)\%(Link)</Link>
     </Compile>
   </ItemGroup>
+
 </Project>

--- a/src/Microsoft.DiaSymReader.Converter/Microsoft.DiaSymReader.Converter.csproj
+++ b/src/Microsoft.DiaSymReader.Converter/Microsoft.DiaSymReader.Converter.csproj
@@ -1,8 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetFrameworkMinimum)</TargetFrameworks>
     <RootNamespace>Microsoft.DiaSymReader.Tools</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -17,6 +16,7 @@
     <!-- Workaround for https://github.com/dotnet/sdk/issues/11270 -->
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PooledObjects" Version="$(MicrosoftCodeAnalysisPooledObjectsVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Debugging" Version="$(MicrosoftCodeAnalysisDebuggingVersion)" PrivateAssets="all" />
@@ -27,10 +27,12 @@
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.DiaSymReader.Converter.UnitTests" />
     <InternalsVisibleTo Include="Pdb2Pdb.UnitTests" />
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Update="ConverterResources.resx" GenerateSource="true" />
   </ItemGroup>
@@ -43,4 +45,5 @@
       <Link Condition="'%(NuGetPackageId)' != ''">%(NuGetPackageId)\%(Link)</Link>
     </Compile>
   </ItemGroup>
+
 </Project>

--- a/src/Microsoft.DiaSymReader.Converter/Utilities/SymReaderHelpers.cs
+++ b/src/Microsoft.DiaSymReader.Converter/Utilities/SymReaderHelpers.cs
@@ -116,11 +116,7 @@ namespace Microsoft.DiaSymReader.Tools
         }
 
         private unsafe static string GetString(byte* data, int size) =>
-#if NET45
-            new string((sbyte*)data, 0, size, Encoding.UTF8);
-#else
             Encoding.UTF8.GetString(data, size);
-#endif
 
         public unsafe static string? GetSourceLinkData(this ISymUnmanagedReader5 reader) => 
             TryGetSourceLinkData(reader, out byte* data, out int size) ? GetString(data, size) : null;

--- a/src/Pdb2Pdb.Tests/Pdb2Pdb.UnitTests.csproj
+++ b/src/Pdb2Pdb.Tests/Pdb2Pdb.UnitTests.csproj
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DiaSymReader.Converter.Xml\Microsoft.DiaSymReader.Converter.Xml.csproj" />
     <ProjectReference Include="..\Microsoft.DiaSymReader.Converter\Microsoft.DiaSymReader.Converter.csproj" />
@@ -14,4 +14,5 @@
   </ItemGroup>
 
   <Import Project="$(RepositoryEngineeringDir)DiaSymReaderNative.targets" />
+
 </Project>

--- a/src/Pdb2Pdb/Pdb2Pdb.csproj
+++ b/src/Pdb2Pdb/Pdb2Pdb.csproj
@@ -1,8 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
     <RootNamespace>Microsoft.DiaSymReader.Tools</RootNamespace>
     <OutputType>Exe</OutputType>
     <LargeAddressAware>true</LargeAddressAware>
@@ -16,19 +15,24 @@
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DiaSymReader.Converter\Microsoft.DiaSymReader.Converter.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="Pdb2Pdb.UnitTests" />
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Update="Resources.resx" GenerateSource="true" />
     <Compile Include="..\Common\NullableAttributes.cs" Link="Common\NullableAttributes.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <NuspecProperty Include="Configuration=$(Configuration)"/>
   </ItemGroup>
 
   <Import Project="$(RepositoryEngineeringDir)DiaSymReaderNative.targets" />
+
 </Project>

--- a/src/Pdb2Xml/Pdb2Xml.csproj
+++ b/src/Pdb2Xml/Pdb2Xml.csproj
@@ -1,8 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
     <RootNamespace>Microsoft.DiaSymReader.Tools</RootNamespace>
     <OutputType>Exe</OutputType>
     <LargeAddressAware>true</LargeAddressAware>
@@ -15,15 +14,19 @@
     <NuspecFile>Pdb2Xml.nuspec</NuspecFile>
     <NuspecBasePath>$(OutputPath)</NuspecBasePath>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DiaSymReader.Converter.Xml\Microsoft.DiaSymReader.Converter.Xml.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Update="Resources.resx" GenerateSource="true" />
   </ItemGroup>
+
   <ItemGroup>
     <NuspecProperty Include="Configuration=$(Configuration)"/>
   </ItemGroup>
 
   <Import Project="$(RepositoryEngineeringDir)DiaSymReaderNative.targets" />
+
 </Project>

--- a/src/PdbTestResources/PdbTestResources.csproj
+++ b/src/PdbTestResources/PdbTestResources.csproj
@@ -1,16 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="Resources\**\*.cs" />
     <Content Include="Resources\**\*.cs" />
     <Content Include="Resources\**\*.cmd" />
     <Content Include="Resources\**\*.txt" />
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="Resources\Async.dll">
       <LogicalName>Async.dll</LogicalName>
@@ -175,4 +176,5 @@
       <LogicalName>CrossGen.dllx</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
+
 </Project>

--- a/src/TestUtilities/TestUtilities.csproj
+++ b/src/TestUtilities/TestUtilities.csproj
@@ -1,13 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net472</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetFrameworkMinimum)</TargetFrameworks>
     <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageReference Include="xunit.assert" Version="$(XunitVersion)" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
…fix build

- Remove unnecessary xml headers from msbuild files
- Remove unnecessary copyright headers from msbuild files
- Remove unnecessary Publishing.props file as v3 is the default
- Use TFM properties instead of hardcoded values (and update to in-support TFMs)
- Fix the build due to compiling against newer version of .NET
- Style clean-up in project files
- Remove unnecessary packaging workaround: Needs https://github.com/dotnet/arcade/pull/16526