### PR TITLE
Upgrade to V4 Arcade publishing

### DIFF
--- a/azure-pipelines-microbuild.yml
+++ b/azure-pipelines-microbuild.yml
@@ -20,8 +20,6 @@ steps:
             -configuration $(BuildConfiguration)
             /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             /p:DotNetSignType=$(SignType)
-            /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-            /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
   displayName: Build
 
 - task: NuGetPublisher@0

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -17,8 +17,6 @@ trigger:
 
 variables:
   - template: /eng/common/templates/variables/pool-providers.yml
-  - name: _PublishUsingPipelines
-    value: true
 
 stages:
 - stage: build
@@ -30,7 +28,6 @@ stages:
       enablePublishBuildArtifacts: true
       enablePublishTestResults: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: $(_PublishUsingPipelines)
       enableTelemetry: true
       helixRepo: dotnet/symreader
       jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,12 +73,13 @@ extends:
           enablePublishBuildArtifacts: true
           enablePublishTestResults: true
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: true
+          publishingVersion: 4
           enableTelemetry: true
           enableSourceBuild: false
           helixRepo: dotnet/symreader
           jobs:
           - job: Windows
+            enablePublishing: ${{ and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}
             pool:
               ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
                 vmImage: 'windows-latest'
@@ -93,7 +94,7 @@ extends:
               - name: _OfficialBuildArgs
                 value: /p:DotNetSignType=$(_SignType) 
                   /p:TeamName=$(TeamName)
-                  /p:DotNetPublishUsingPipelines=true
+                 
                   /p:DotNetArtifactsCategory=true
                   /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             # else
@@ -170,5 +171,5 @@ extends:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
-          publishingInfraVersion: 3
+          publishingInfraVersion: 4
           enableSymbolValidation: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
+      <PublishingVersion>4</PublishingVersion>
    </PropertyGroup>
 </Project>


### PR DESCRIPTION
Related to dotnet/arcade#16697.

This updates the repo from Arcade V3 publishing to V4 by:
- setting PublishingVersion to 4
- switching pipeline jobs to V4 publishingVersion/enablePublishing
- removing legacy V3 publish toggles