### PR TITLE
Fix OfficialBuildId not flowing to official build (1.1.0-ci publish conflict)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,9 +92,8 @@ extends:
             # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
               - group: Publish-Build-Assets
               - name: _OfficialBuildArgs
-                value: /p:DotNetSignType=$(_SignType) 
+                value: /p:DotNetSignType=$(_SignType)
                   /p:TeamName=$(TeamName)
-                 
                   /p:DotNetArtifactsCategory=true
                   /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             # else


### PR DESCRIPTION
## Problem

The daily official build fails during post-build publishing with package conflicts:

```
error : Package '...Microsoft.DiaSymReader.Converter.Xml.1.1.0-ci.nupkg' already exists ... with different content. (Final status: ExistsAndDifferent)
```

Failing build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2986686 (and its promotion build 2986725).

## Root cause

Packages were produced with the fixed version `1.1.0-ci` — the non-official `-ci` label with no build-id/date stamp. Every official build produced the *identical* version, so publishing collided with the previous day's package.

The reason `OfficialBuildId` never reached the build: a stray blank line was inserted into the middle of the `_OfficialBuildArgs` multi-line YAML plain scalar (in the V4 Arcade publishing upgrade, #333). In YAML, a blank line inside a plain scalar folds to a literal newline, so the value became:

```
/p:DotNetSignType=real /p:TeamName=Roslyn<newline>/p:DotNetArtifactsCategory=true /p:OfficialBuildId=20260528.1
```

When substituted into the `- script: eng\common\cibuild.cmd ... $(_BuildArgs)` step, the newline split the command — `cibuild.cmd` only received `DotNetSignType` and `TeamName`, while `/p:OfficialBuildId=...` landed on an orphaned line and was never passed to the build. Without `OfficialBuildId`, Arcade falls back to the `-ci` label.

## Fix

Remove the stray blank line so the value folds back into a single line and `OfficialBuildId` is passed correctly. Official builds will again produce date-stamped versions (e.g. `1.1.0-beta2.YYMMDD.r`), eliminating the conflict.
