### PR TITLE
Use CPM and update package versions, consolidate TFMs

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,4 +9,8 @@
   <disabledPackageSources>
     <clear />
   </disabledPackageSources>
+  <auditSources>
+    <clear />
+    <add key="nuget.org" value="https://data.nuget.org/v3/index.json" />
+  </auditSources>
 </configuration>

--- a/eng/DiaSymReaderNative.targets
+++ b/eng/DiaSymReaderNative.targets
@@ -20,17 +20,22 @@
     out. This logic is responsible for doing that.
   -->
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
-    <Content Include="$(NuGetPackageRoot)\microsoft.diasymreader.native\$(MicrosoftDiaSymReaderNativeVersion)\runtimes\win\native\Microsoft.DiaSymReader.Native.x86.dll">
+    <DiaSymReaderNativePackage
+      Include="Microsoft.DiaSymReader.Native"
+      PackageVersion="@(PackageVersion->WithMetadataValue('Identity', 'Microsoft.DiaSymReader.Native')->Metadata('Version'))"
+      PackagePath="$(NuGetPackageRoot)\microsoft.diasymreader.native\%(PackageVersion)\" />
+
+    <Content Include="@(DiaSymReaderNativePackage->'%(PackagePath)runtimes\win\native\Microsoft.DiaSymReader.Native.x86.dll')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
       <Pack>false</Pack>
     </Content>
-    <Content Include="$(NuGetPackageRoot)\microsoft.diasymreader.native\$(MicrosoftDiaSymReaderNativeVersion)\runtimes\win\native\Microsoft.DiaSymReader.Native.amd64.dll">
+    <Content Include="@(DiaSymReaderNativePackage->'%(PackagePath)runtimes\win\native\Microsoft.DiaSymReader.Native.amd64.dll')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
       <Pack>false</Pack>
     </Content>
 
-    <PackageReference Include="Microsoft.DiaSymReader.Native" ExcludeAssets="all"/>
+    <PackageDownload Include="@(DiaSymReaderNativePackage)" Version="[%(PackageVersion)]" />
   </ItemGroup>
 </Project>

--- a/eng/DiaSymReaderNative.targets
+++ b/eng/DiaSymReaderNative.targets
@@ -20,22 +20,18 @@
     out. This logic is responsible for doing that.
   -->
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
-    <DiaSymReaderNativePackage
-      Include="Microsoft.DiaSymReader.Native"
-      PackageVersion="@(PackageVersion->WithMetadataValue('Identity', 'Microsoft.DiaSymReader.Native')->Metadata('Version'))"
-      PackagePath="$(NuGetPackageRoot)\microsoft.diasymreader.native\%(PackageVersion)\" />
-
-    <Content Include="@(DiaSymReaderNativePackage->'%(PackagePath)runtimes\win\native\Microsoft.DiaSymReader.Native.x86.dll')">
+    <Content Include="$(PkgMicrosoft_DiaSymReader_Native)\runtimes\win\native\Microsoft.DiaSymReader.Native.x86.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
       <Pack>false</Pack>
     </Content>
-    <Content Include="@(DiaSymReaderNativePackage->'%(PackagePath)runtimes\win\native\Microsoft.DiaSymReader.Native.amd64.dll')">
+    <Content Include="$(PkgMicrosoft_DiaSymReader_Native)\runtimes\win\native\Microsoft.DiaSymReader.Native.amd64.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
       <Pack>false</Pack>
     </Content>
 
-    <PackageDownload Include="@(DiaSymReaderNativePackage)" Version="[%(PackageVersion)]" />
+    <PackageReference Include="Microsoft.DiaSymReader.Native" GeneratePathProperty="true" ExcludeAssets="all"/>
   </ItemGroup>
+
 </Project>

--- a/eng/DiaSymReaderNative.targets
+++ b/eng/DiaSymReaderNative.targets
@@ -31,6 +31,6 @@
       <Pack>false</Pack>
     </Content>
 
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" ExcludeAssets="all"/>
+    <PackageReference Include="Microsoft.DiaSymReader.Native" ExcludeAssets="all"/>
   </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,17 +7,5 @@
     <SemanticVersioningV1>true</SemanticVersioningV1>
     <UsingToolNuGetRepack>true</UsingToolNuGetRepack>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
-    <!-- libs -->
-    <MicrosoftCodeAnalysisPooledObjectsVersion>4.1.0-1.21523.2</MicrosoftCodeAnalysisPooledObjectsVersion>
-    <MicrosoftCodeAnalysisDebuggingVersion>4.1.0-1.21523.2</MicrosoftCodeAnalysisDebuggingVersion>
-    <MicrosoftDiaSymReaderVersion>1.4.0-beta2-21528-01</MicrosoftDiaSymReaderVersion>
-    <MicrosoftDiaSymReaderNativeVersion>17.0.0-beta1.21524.1</MicrosoftDiaSymReaderNativeVersion>
-    <MicrosoftDiaSymReaderPortablePdbVersion>1.7.0-beta-21525-03</MicrosoftDiaSymReaderPortablePdbVersion>
-    <MicrosoftMetadataVisualizerVersion>1.0.0-beta3.21151.2</MicrosoftMetadataVisualizerVersion>
-    <MicrosoftSourceLinkToolsVersion>1.1.0-beta-20527-03</MicrosoftSourceLinkToolsVersion>
-    <!-- CoreFX -->
-    <SystemCollectionsImmutableVersion>5.0.0</SystemCollectionsImmutableVersion>
-    <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
-    <SystemTextJsonVersion>5.0.0</SystemTextJsonVersion>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,5 +8,8 @@
     <Nullable>annotations</Nullable>
     <Nullable Condition="'$(TargetFramework)' != 'net472'">enable</Nullable>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+
+    <!-- Bump minimum supported .NET Framework version -->
+    <NetFrameworkMinimum>net472</NetFrameworkMinimum>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,5 +11,8 @@
 
     <!-- Bump minimum supported .NET Framework version -->
     <NetFrameworkMinimum>net472</NetFrameworkMinimum>
+
+    <!-- TODO: Fix .NET Framework flagged vulnerabilities -->
+    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,8 +11,5 @@
 
     <!-- Bump minimum supported .NET Framework version -->
     <NetFrameworkMinimum>net472</NetFrameworkMinimum>
-
-    <!-- TODO: Fix .NET Framework flagged vulnerabilities -->
-    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,7 +30,7 @@
 
     <!-- external -->
     <PackageVersion Include="Microsoft.Metadata.Visualizer" Version="1.0.0-beta3.21151.2" />
-    <PackageVersion Include="xunit.assert" Version="$(XunitVersion)" />
+    <PackageVersion Include="xunit.assert" Version="$(XunitVersion)" Condition="'$(IsTestProject)' != 'true'" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,35 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- roslyn -->
+    <PackageReference Include="Microsoft.CodeAnalysis.Debugging" Version="4.1.0-1.21523.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PooledObjects" Version="4.1.0-1.21523.2" />
+
+    <!-- roslyn-debug -->
+    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="17.0.0-beta1.21524.1" />
+
+    <!-- sourcelink-->
+    <PackageReference Include="Microsoft.SourceLink.Tools" Version="10.0.301" />
+
+    <!-- symreader -->
+    <PackageReference Include="Microsoft.DiaSymReader" Version="2.2.10" />
+
+    <!-- symreader-portable -->
+    <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="1.7.0-beta-21525-03" />
+
+    <!-- runtime-->
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.10" />
+    <PackageReference Include="System.Reflection.Metadata" Version="10.0.10" />
+    <PackageReference Include="System.Text.Json" Version="10.0.10" />
+
+    <!-- external -->
+    <PackageReference Include="Microsoft.Metadata.Visualizer" Version="1.0.0-beta3.21151.2" />
+    <PackageReference Include="xunit.assert" Version="$(XunitVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.DiaSymReader" Version="2.2.10" />
 
     <!-- symreader-portable -->
-    <PackageVersion Include="Microsoft.DiaSymReader.PortablePdb" Version="1.7.0-beta-21525-03" />
+    <PackageVersion Include="Microsoft.DiaSymReader.PortablePdb" Version="2.0.0-beta-26059-01" />
 
     <!-- runtime-->
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.10" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,29 +7,29 @@
 
   <ItemGroup>
     <!-- roslyn -->
-    <PackageReference Include="Microsoft.CodeAnalysis.Debugging" Version="4.1.0-1.21523.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.PooledObjects" Version="4.1.0-1.21523.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Debugging" Version="4.1.0-1.21523.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.PooledObjects" Version="4.1.0-1.21523.2" />
 
     <!-- roslyn-debug -->
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="17.0.0-beta1.21524.1" />
+    <PackageVersion Include="Microsoft.DiaSymReader.Native" Version="17.0.0-beta1.21524.1" />
 
     <!-- sourcelink-->
-    <PackageReference Include="Microsoft.SourceLink.Tools" Version="10.0.301" />
+    <PackageVersion Include="Microsoft.SourceLink.Tools" Version="10.0.301" />
 
     <!-- symreader -->
-    <PackageReference Include="Microsoft.DiaSymReader" Version="2.2.10" />
+    <PackageVersion Include="Microsoft.DiaSymReader" Version="2.2.10" />
 
     <!-- symreader-portable -->
-    <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="1.7.0-beta-21525-03" />
+    <PackageVersion Include="Microsoft.DiaSymReader.PortablePdb" Version="1.7.0-beta-21525-03" />
 
     <!-- runtime-->
-    <PackageReference Include="System.Collections.Immutable" Version="10.0.10" />
-    <PackageReference Include="System.Reflection.Metadata" Version="10.0.10" />
-    <PackageReference Include="System.Text.Json" Version="10.0.10" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.10" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="10.0.10" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.10" />
 
     <!-- external -->
-    <PackageReference Include="Microsoft.Metadata.Visualizer" Version="1.0.0-beta3.21151.2" />
-    <PackageReference Include="xunit.assert" Version="$(XunitVersion)" />
+    <PackageVersion Include="Microsoft.Metadata.Visualizer" Version="1.0.0-beta3.21151.2" />
+    <PackageVersion Include="xunit.assert" Version="$(XunitVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DiaSymReader.Converter.Tests/Microsoft.DiaSymReader.Converter.UnitTests.csproj
+++ b/src/Microsoft.DiaSymReader.Converter.Tests/Microsoft.DiaSymReader.Converter.UnitTests.csproj
@@ -2,18 +2,18 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCurrent);net472</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- 
       We would need to download 32bit dotnet cli, which would add extra time to PR runs 
       Testing 64bit only on Desktop suffixiently covers our interop code paths.  
     -->
-    <TestArchitectures Condition="'$(TargetFramework)' == 'net472'">x64;x86</TestArchitectures>
-
+    <TestArchitectures Condition="'$(TargetFramework)' == '$(NetFrameworkCurrent)'">x64;x86</TestArchitectures>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.Metadata.Visualizer" Version="$(MicrosoftMetadataVisualizerVersion)" />
-    <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbVersion)" />
+    <PackageReference Include="Microsoft.Metadata.Visualizer" />
+    <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" />
     <ProjectReference Include="..\Microsoft.DiaSymReader.Converter.Xml\Microsoft.DiaSymReader.Converter.Xml.csproj" />
     <ProjectReference Include="..\Microsoft.DiaSymReader.Converter\Microsoft.DiaSymReader.Converter.csproj" />
     <ProjectReference Include="..\PdbTestResources\PdbTestResources.csproj" />

--- a/src/Microsoft.DiaSymReader.Converter.Xml/Microsoft.DiaSymReader.Converter.Xml.csproj
+++ b/src/Microsoft.DiaSymReader.Converter.Xml/Microsoft.DiaSymReader.Converter.Xml.csproj
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetFrameworkMinimum)</TargetFrameworks>
     <RootNamespace>Microsoft.DiaSymReader.Tools</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -24,13 +24,13 @@
     <Compile Include="..\Microsoft.DiaSymReader.Converter\Utilities\DummySymReaderMetadataProvider.cs" Link="Utilities\DummySymReaderMetadataProvider.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" />
-    <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" Version="$(MicrosoftDiaSymReaderPortablePdbVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.PooledObjects" Version="$(MicrosoftCodeAnalysisPooledObjectsVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Debugging" Version="$(MicrosoftCodeAnalysisDebuggingVersion)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DiaSymReader" />
+    <PackageReference Include="Microsoft.DiaSymReader.Native" />
+    <PackageReference Include="Microsoft.DiaSymReader.PortablePdb" />
+    <PackageReference Include="System.Collections.Immutable" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
+    <PackageReference Include="System.Reflection.Metadata" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PooledObjects" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Debugging" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="PdbToXmlResources.resx" GenerateSource="true" />

--- a/src/Microsoft.DiaSymReader.Converter.Xml/Token2SourceLineExporter.cs
+++ b/src/Microsoft.DiaSymReader.Converter.Xml/Token2SourceLineExporter.cs
@@ -6,6 +6,7 @@
 #pragma warning disable IDE0018 // Inline variable declaration
 #pragma warning disable IDE0059 // Unnecessary assignment of a value
 #pragma warning disable IDE0060 // Remove unused parameter
+#pragma warning disable CS8981 // he type name 'bucket' only contains lower-cased ascii characters. Such names may become reserved for the language.
 
 using System;
 using System.Collections.Generic;
@@ -77,7 +78,11 @@ namespace Microsoft.DiaSymReader.Tools
             internal void FillBuffer(Stream stream, int capacity)
             {
                 MinCapacity(capacity);
+#if NET
+                stream.ReadExactly(_buffer, 0, capacity);
+#else
                 stream.Read(_buffer, 0, capacity);
+#endif
                 _offset = 0;
             }
 
@@ -90,7 +95,11 @@ namespace Microsoft.DiaSymReader.Tools
                     Array.Copy(_buffer, newBuffer, _buffer.Length);
                     _buffer = newBuffer;
                 }
+#if NET
+                stream.ReadExactly(_buffer, _offset, count);
+#else
                 stream.Read(_buffer, _offset, count);
+#endif
                 _offset += count;
             }
 
@@ -867,7 +876,11 @@ namespace Microsoft.DiaSymReader.Tools
 
             internal void Read(byte[] bytes, int offset, int count)
             {
+#if NET
+                reader.ReadExactly(bytes, offset, count);
+#else
                 reader.Read(bytes, offset, count);
+#endif
             }
 
             internal int PagesFromSize(int size)

--- a/src/Microsoft.DiaSymReader.Converter/Microsoft.DiaSymReader.Converter.csproj
+++ b/src/Microsoft.DiaSymReader.Converter/Microsoft.DiaSymReader.Converter.csproj
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetFrameworkMinimum)</TargetFrameworks>
     <RootNamespace>Microsoft.DiaSymReader.Tools</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -18,14 +18,14 @@
     <GenerateDependencyFile>false</GenerateDependencyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.PooledObjects" Version="$(MicrosoftCodeAnalysisPooledObjectsVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Debugging" Version="$(MicrosoftCodeAnalysisDebuggingVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" />
-    <PackageReference Include="Microsoft.SourceLink.Tools" Version="$(MicrosoftSourceLinkToolsVersion)" PrivateAssets="all" />
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PooledObjects" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Debugging" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DiaSymReader" />
+    <PackageReference Include="Microsoft.DiaSymReader.Native" />
+    <PackageReference Include="Microsoft.SourceLink.Tools" PrivateAssets="all" />
+    <PackageReference Include="System.Collections.Immutable" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
+    <PackageReference Include="System.Reflection.Metadata" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
+    <PackageReference Include="System.Text.Json" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.DiaSymReader.Converter.UnitTests" />

--- a/src/Pdb2Pdb.Tests/Pdb2Pdb.UnitTests.csproj
+++ b/src/Pdb2Pdb.Tests/Pdb2Pdb.UnitTests.csproj
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Pdb2Pdb/Pdb2Pdb.csproj
+++ b/src/Pdb2Pdb/Pdb2Pdb.csproj
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
     <RootNamespace>Microsoft.DiaSymReader.Tools</RootNamespace>
     <OutputType>Exe</OutputType>
     <LargeAddressAware>true</LargeAddressAware>

--- a/src/Pdb2Xml/Pdb2Xml.csproj
+++ b/src/Pdb2Xml/Pdb2Xml.csproj
@@ -2,7 +2,7 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
     <RootNamespace>Microsoft.DiaSymReader.Tools</RootNamespace>
     <OutputType>Exe</OutputType>
     <LargeAddressAware>true</LargeAddressAware>

--- a/src/TestUtilities/TestUtilities.csproj
+++ b/src/TestUtilities/TestUtilities.csproj
@@ -2,12 +2,12 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the License.txt file in the project root for more information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net472</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
-    <PackageReference Include="xunit.assert" Version="$(XunitVersion)" />
+    <PackageReference Include="System.Collections.Immutable" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
+    <PackageReference Include="System.Reflection.Metadata" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
+    <PackageReference Include="xunit.assert" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Use CPM and update to recent package versions to avoid netstandard1.x dependencies
- Use NetMinimum, NetCurrent and NetFrameworkMinimum and NetFrameworkCurrent TFM properties