### PR TITLE
Remove Publish-Build-Assets variable group from main

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,8 +89,6 @@ extends:
             variables:
             # Only enable publishing in official builds
             - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-              - group: Publish-Build-Assets
               - name: _OfficialBuildArgs
                 value: /p:DotNetSignType=$(_SignType)
                   /p:TeamName=$(TeamName)


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `azure-pipelines.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131